### PR TITLE
Batching Stats write and name conflict fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 docker_image := iomete.azurecr.io/iomete/iomete_data_compaction
-docker_tag := 1.2.5
+docker_tag := 1.2.6
 
 test:
 	pytest --capture=no --log-cli-level=DEBUG

--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ You can specify additional configurations
     // The catalog for which to run compaction
     catalog: "spark_catalog",
     
+    // Batch size for stats collection (default: 100)
+    // Higher values reduce database writes but use more memory
+    // Set to 1 to disable batching (immediate writes)
+    stats_batch_size: 100,
+    
     // Databases in the catalog for which to run compaction
     // Defaults to empty array
     // In case the input is an empty array then we consider all databases in the provided catalog for compaction 

--- a/application.conf
+++ b/application.conf
@@ -1,5 +1,7 @@
 {
     catalog: "spark_catalog",
+    stats_batch_size: 100,
+    
     expire_snapshot: {
         // Number of ancestor snapshots to preserve regardless of `older_than`
         // DEFAULT: 1

--- a/data_compaction_job/config.py
+++ b/data_compaction_job/config.py
@@ -47,6 +47,7 @@ class ApplicationConfig:
     gc_handling: GCHandlingConfig = field(default_factory=GCHandlingConfig)
     include_exclude: IncludeExcludeConfig = field(default_factory=IncludeExcludeConfig)
     parallelism: int = 4
+    stats_batch_size: int = 100
     table_overrides: dict[str, dict] = None
 
 
@@ -89,6 +90,9 @@ def get_config(application_config_path) -> ApplicationConfig:
 
     if "parallelism" in config:
         app_config.parallelism = config.get("parallelism", 4)
+
+    if "stats_batch_size" in config:
+        app_config.stats_batch_size = config.get("stats_batch_size", 100)
 
     if "databases" in config:
         app_config.include_exclude.databases = config.get("databases", [])

--- a/data_compaction_job/sql_compaction.py
+++ b/data_compaction_job/sql_compaction.py
@@ -129,7 +129,7 @@ class SqlCompaction:
                                                            "expire_snapshot",
                                                            "retain_last")
                          or self.config.expire_snapshot.retain_last)
-        options = (f"table => '{database}.{table_name}',"
+        options = (f"table => '`{catalog}`.`{database}`.`{table_name}`',"
                    f" retain_last => {retain_last},"
                    f" older_than => TIMESTAMP '{timestamp}'")
         query = f"CALL {catalog}.system.expire_snapshots({options})"
@@ -144,14 +144,14 @@ class SqlCompaction:
                                                      "older_than_days")
                    or self.config.remove_orphan_files.older_than_days)
         timestamp = datetime.now(timezone.utc) - timedelta(days=days)
-        options = f"table => '{database}.{table_name}', older_than => TIMESTAMP '{timestamp}'"
+        options = f"table => '`{catalog}`.`{database}`.`{table_name}`', older_than => TIMESTAMP '{timestamp}'"
         query = f"CALL {catalog}.system.remove_orphan_files({options})"
         result = self.spark.sql(query).collect()
         return result, query
 
     @emit_stats("REWRITE_MANIFESTS")
     def __rewrite_manifest(self, catalog, database, table_name):
-        options = f"table => '{database}.{table_name}'"
+        options = f"table => '`{catalog}`.`{database}`.`{table_name}`'"
         use_caching = (self.__get_final_config_for_table(database,
                                                      table_name,
                                                      "rewrite_manifest",
@@ -187,7 +187,7 @@ class SqlCompaction:
                                                      "where")
                     or self.config.rewrite_data_files.where)
 
-        options = f"table => '{database}.{table_name}'"
+        options = f"table => '`{catalog}`.`{database}`.`{table_name}`'"
 
         if strategy and strategy == "sort":
             options += f", strategy => {strategy}, sort_order => {sort_order}"

--- a/data_compaction_job/stats_emitter.py
+++ b/data_compaction_job/stats_emitter.py
@@ -2,10 +2,126 @@ import logging
 import time
 from datetime import datetime, timezone
 from functools import wraps
+from threading import Lock
+from typing import List, Dict, Any
 
 from pyspark.sql import SparkSession
+from pyspark.sql.types import StructType, StructField, StringType, TimestampType, MapType
 
 logger = logging.getLogger(__name__)
+
+class StatsBatcher:
+    
+    def __init__(self, batch_size: int = 100):
+        self.batch_size = batch_size
+        self.metrics_batch: List[Dict[str, Any]] = []
+        self.errors_batch: List[Dict[str, Any]] = []
+        self.lock = Lock()
+        
+    def add_metric(self, spark_app_id: str, catalog_name: str, database_name: str, 
+                   table_name: str, operation: str, query: str, metrics: Dict[str, str], 
+                   start_time: datetime, end_time: datetime):
+        with self.lock:
+            self.metrics_batch.append({
+                'spark_app_id': spark_app_id,
+                'catalog_name': catalog_name,
+                'database_name': database_name,
+                'table_name': table_name,
+                'operation': operation,
+                'query': query,
+                'metrics': metrics,
+                'start_time': start_time,
+                'end_time': end_time
+            })
+            
+            if len(self.metrics_batch) >= self.batch_size:
+                self._flush_metrics_batch()
+    
+    def add_error(self, spark_app_id: str, catalog_name: str, database_name: str, 
+                  table_name: str, operation: str, error: str, 
+                  start_time: datetime, end_time: datetime):
+        with self.lock:
+            self.errors_batch.append({
+                'spark_app_id': spark_app_id,
+                'catalog_name': catalog_name,
+                'database_name': database_name,
+                'table_name': table_name,
+                'operation': operation,
+                'error': error,
+                'start_time': start_time,
+                'end_time': end_time
+            })
+            
+            if len(self.errors_batch) >= self.batch_size:
+                self._flush_errors_batch()
+    
+    def _flush_metrics_batch(self):
+        if not self.metrics_batch or not hasattr(self, 'spark'):
+            return
+            
+        try:
+            metrics_schema = StructType([
+                StructField("spark_app_id", StringType(), True),
+                StructField("catalog_name", StringType(), True),
+                StructField("database_name", StringType(), True),
+                StructField("table_name", StringType(), True),
+                StructField("operation", StringType(), True),
+                StructField("query", StringType(), True),
+                StructField("metrics", MapType(StringType(), StringType()), True),
+                StructField("start_time", TimestampType(), True),
+                StructField("end_time", TimestampType(), True)
+            ])
+            df = self.spark.createDataFrame(self.metrics_batch, schema=metrics_schema)
+            df.write.mode("append").insertInto("spark_catalog.iomete_system_db.table_optimisation_run_metrics")
+            
+            logger.info(f"Flushed {len(self.metrics_batch)} metric records to database")
+            self.metrics_batch.clear()
+            
+        except Exception as e:
+            logger.error(f"Error flushing metrics batch: {e}")
+            # Keep the batch for retry or manual handling
+    
+    def _flush_errors_batch(self):
+        if not self.errors_batch or not hasattr(self, 'spark'):
+            return
+            
+        try:
+            errors_schema = StructType([
+                StructField("spark_app_id", StringType(), True),
+                StructField("catalog_name", StringType(), True),
+                StructField("database_name", StringType(), True),
+                StructField("table_name", StringType(), True),
+                StructField("operation", StringType(), True),
+                StructField("error", StringType(), True),
+                StructField("start_time", TimestampType(), True),
+                StructField("end_time", TimestampType(), True)
+            ])
+
+            df = self.spark.createDataFrame(self.errors_batch, schema=errors_schema)
+            df.write.mode("append").insertInto("spark_catalog.iomete_system_db.table_optimisation_run_errors")
+            
+            logger.info(f"Flushed {len(self.errors_batch)} error records to database")
+            self.errors_batch.clear()
+            
+        except Exception as e:
+            logger.error(f"Error flushing errors batch: {e}")
+            # Keep the batch for retry or manual handling
+    
+    def flush_all(self):
+        """Flush all remaining records in both batches."""
+        with self.lock:
+            if self.metrics_batch:
+                self._flush_metrics_batch()
+            if self.errors_batch:
+                self._flush_errors_batch()
+    
+    def set_spark_session(self, spark: SparkSession):
+        """Set the Spark session for database operations."""
+        self.spark = spark
+
+# Global batcher instance
+_stats_batcher = StatsBatcher()
+
 def emit_stats(operation: str):
     """Emits metric for the table optimisation operation that is being performed."""
 
@@ -24,45 +140,50 @@ def emit_stats(operation: str):
                 #post-execute error scenario
                 end_time = time.time()
                 spark: SparkSession = args[0].spark
-                spark.sql(f"""INSERT INTO spark_catalog.iomete_system_db.table_optimisation_run_errors VALUES (
-                      '{spark.sparkContext.applicationId}',
-                      '{args[1]}',
-                      '{args[2]}',
-                      '{args[3]}',
-                      '{operation}',
-                      '{str(e)}',
-                      TIMESTAMP '{datetime.fromtimestamp(start_time ,timezone.utc).strftime('%Y-%m-%d %H:%M:%S')}',
-                      TIMESTAMP '{datetime.fromtimestamp(end_time, timezone.utc).strftime('%Y-%m-%d %H:%M:%S')}'
-                    )""")
+
+                _stats_batcher.add_error(
+                    spark_app_id=spark.sparkContext.applicationId,
+                    catalog_name=args[1],
+                    database_name=args[2],
+                    table_name=args[3],
+                    operation=operation,
+                    error=str(e),
+                    start_time=datetime.fromtimestamp(start_time, timezone.utc),
+                    end_time=datetime.fromtimestamp(end_time, timezone.utc)
+                )
                 logger.error(f"[{args[2]}.{args[3]}] Error running {operation} on table, error={e}")
             else:
                 #post-execute happy scenario
                 end_time = time.time()
 
                 if operation == "REMOVE_ORPHAN_FILES":
-                    metric_map = f"'removed file count', '{len(metrics)}'"
+                    metrics_map = {'removed file count': str(len(metrics))}
                 else:
-                    metric_map = ", ".join([f"'{key}', '{value}'" for key, value in metrics[0].asDict().items()])
+                    metrics_map = {key: str(value) for key, value in metrics[0].asDict().items()}
 
                 spark: SparkSession = args[0].spark
-                sql = sql.replace("'", "''")
-                spark.sql(f"""INSERT INTO spark_catalog.iomete_system_db.table_optimisation_run_metrics VALUES (
-      '{spark.sparkContext.applicationId}',
-      '{args[1]}',
-      '{args[2]}',
-      '{args[3]}',
-      '{operation}',
-      '{sql}',
-      MAP({metric_map}),
-      TIMESTAMP '{datetime.fromtimestamp(start_time, timezone.utc).strftime('%Y-%m-%d %H:%M:%S')}',
-      TIMESTAMP '{datetime.fromtimestamp(end_time, timezone.utc).strftime('%Y-%m-%d %H:%M:%S')}'
-    )""")
+                _stats_batcher.add_metric(
+                    spark_app_id=spark.sparkContext.applicationId,
+                    catalog_name=args[1],
+                    database_name=args[2],
+                    table_name=args[3],
+                    operation=operation,
+                    query=sql,
+                    metrics=metrics_map,
+                    start_time=datetime.fromtimestamp(start_time, timezone.utc),
+                    end_time=datetime.fromtimestamp(end_time, timezone.utc)
+                )
 
         return wrapper_func
 
     return decorator
 
-def init_emitter(spark: SparkSession):
+def init_emitter(spark: SparkSession, batch_size: int = 100):
+    global _stats_batcher
+    _stats_batcher = StatsBatcher(batch_size=batch_size)
+    _stats_batcher.set_spark_session(spark)
+    
+    # Create the necessary database and tables
     spark.sql("create DATABASE IF NOT EXISTS spark_catalog.iomete_system_db")
     spark.sql("""create TABLE IF NOT EXISTS spark_catalog.iomete_system_db.table_optimisation_run_metrics (
   spark_app_id VARCHAR(255),
@@ -93,3 +214,9 @@ def init_emitter(spark: SparkSession):
   )""")
     spark.sql(" ALTER TABLE spark_catalog.iomete_system_db.table_optimisation_run_metrics SET TBLPROPERTIES ('commit.retry.num-retries' = '200') ")
     spark.sql(" ALTER TABLE spark_catalog.iomete_system_db.table_optimisation_run_errors SET TBLPROPERTIES ('commit.retry.num-retries' = '200') ")
+
+def close_emitter(spark: SparkSession):
+    global _stats_batcher
+    if _stats_batcher:
+        _stats_batcher.flush_all()
+        logger.info("Stats emitter closed and all batches flushed")

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = data_compaction_job
-version = 1.2.5
+version = 1.2.6
 author = Fuad M.
 author_email = fuad@iomete.com
 description = iomete: Data Compaction Job


### PR DESCRIPTION
Writes to run metrics and error metrics tables now happen in batches

https://linear.app/iomete/issue/SUP-471/data-compaction-job
Fixes the below issue

Sample tables layout

catalog1
   - catalog1  -> database name
     - table1
spark_catalog
  - catalog1
    - table1

Command that fails
CALL spark_catalog.system.rewrite_data_files(table => 'catalog1.table1');

Command that works
CALL spark_catalog.system.rewrite_data_files(table => '`spark_catalog`.`catalog1`.`table1`');
